### PR TITLE
Fix arc podspec

### DIFF
--- a/SMXMLDocument.podspec
+++ b/SMXMLDocument.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SMXMLDocument"
-  s.version      = "1.0"
+  s.version      = "1.0.1"
   s.summary      = "A lightweight XML Document class for iOS."
   s.description  = <<-DESC
                     SMXMLDocument is a very handy lightweight XML parser for iOS.
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nfarina/xmldocument"
   s.license      = 'MIT License'
   s.author       = { "Nick Farina" => "nfarina@gmail.com" }
-  s.source       = { :git => "https://github.com/nfarina/webrequest.git", :tag => "1.0" }
+  s.source       = { :git => "https://github.com/nfarina/xmldocument.git", :tag => s.version.to_s }
   s.platform     = :ios
-  s.source_files = 'SMWebRequest.{h,m}'
-  s.requires_arc = false
+  s.source_files = 'SMXMLDocument.{h,m}'
+  s.requires_arc = true
 end


### PR DESCRIPTION
The podspec appears to have been copied from SMWebRequest,
but was never completely modified to match with xmldocument.
- Fixed the source link
- Dynamically set tag to version name
- Fix incorrect source_files
- Requires arc

Should be tagged as 1.0.1
